### PR TITLE
Change `kerenel` to `kernel`

### DIFF
--- a/src/what-kind-is-there.md
+++ b/src/what-kind-is-there.md
@@ -34,7 +34,7 @@ This means that monolithic kernels are kind of ‘the default’. Other kernels
 usually define themselves by solving some kind of problem that monolithic
 kernels have.
 
-If a monolithic kerenel were a web application, it would be a big ‘ol Rails
+If a monolithic kernel were a web application, it would be a big ‘ol Rails
 application. One repository. A million subdirectories. It may be a big ball
 of mud, but it pays the bills.
 
@@ -49,7 +49,7 @@ Mach, the kernel that Mac OS X uses, is a microkernel. Well, sort of. It ended
 up being one, but Mac OS X uses a version of Mach from before that work was
 done... so it’s a bit blurry.
 
-If a microkerenel were a web application, it would be a microservice. And a
+If a microkernel were a web application, it would be a microservice. And a
 bunch of the other stuff that’s in kernel space in a monolithic kernel are
 other microservices, but in userspace instead. It’s a bit cooler than a single
 monolithic web app by itself, and the communication is nice for flexibility’s


### PR DESCRIPTION
There are two instances of `kernel` being misspelled as `kerenel`
