### PR TITLE
multiboot-headers: add more explanation on the end tag

### DIFF
--- a/src/multiboot-headers.md
+++ b/src/multiboot-headers.md
@@ -275,7 +275,11 @@ TODO: https://github.com/intermezzOS/book/issues/28
 
 ### Ending tag
 
-Finally, we have one more required bit: the end tag. it looks like this:
+After the checksum you can list a series of “tags”, which is a way for the OS to
+tell the bootloader to do some extra things before handing control over to the
+OS, or to give the OS some extra information once started. We donʼt need any of
+that yet, though, so we just need to include the required “end tag”, which looks
+like this:
 
 ```x86asm
 header_start:
@@ -298,8 +302,6 @@ bytes on the x86\_64 architecture. The multiboot specification demands that this
 be exactly a word. You’ll find that this is super common in operating systems:
 the exact size and amount of everything matters. It’s just a side-effect of
 working at a low level.
-
-TODO: https://github.com/intermezzOS/book/issues/29
 
 ### The Section
 
@@ -359,10 +361,3 @@ specification. We wrote a Multiboot-compliant header file in assembly code, and
 used `nasm` to create an object file from it.
 
 Next, we’ll write the actual code that prints “Hello world” to the screen.
-
-
-
-
-
-
-


### PR DESCRIPTION
This adds a brief explanation on what the tags in the header can do.

I thought about adding a paragraph explaining how each tag has the same format (a word specifying the type, another word with some flags for the tag (such as whether itʼs optional or not), and a double word specifying the length of the entire tag, followed by some tag-specific data (thereʼs no tag-specific data for the end tag)), but that might be too much to explain right now and is maybe better suited for if/when we come back to adding more tags in a future section?

Potentially solves #29, so I removed the TODO for that.
