### PR TITLE
Add .nojekyll file to fix missing font-awesome in HTTPS

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -15,6 +15,7 @@ git fetch upstream
 git reset upstream/gh-pages
 
 touch .
+touch .nojekyll
 
 git add -A .
 git commit -m "rebuild pages at ${rev}"


### PR DESCRIPTION
When opening the book site on HTTPS some icons are missing because the [fallback font-awesome CSS](https://intermezzos.github.io/book/_FontAwesome/css/font-awesome.css) fails to load.

Adding a `.nojekyll` file to the root of the `gh-pages` branch seems to fix this, as explained [here](https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/).
