### PR TITLE
Reference A20 line instead of A20 pin

### DIFF
--- a/src/multiboot-headers.md
+++ b/src/multiboot-headers.md
@@ -123,7 +123,7 @@ read this information, and follow it to do the right thing.
 One other advantage of using GRUB: it will handle the transition from real mode
 to protected mode for us, skipping the first step. We don’t even need to know
 anything about all of that old stuff. If you’re curious about the kinds of
-things you would have needed to know, put “A20 pin” into your favorite search
+things you would have needed to know, put “A20 line” into your favorite search
 engine, and get ready to cry yourself to sleep.
 
 ## Writing our own Multiboot header


### PR DESCRIPTION
`A20 pin` didn't give me many hits, but `A20 line` left me in tears

Reference: [A20 line](https://en.wikipedia.org/wiki/A20_line)
