### PR TITLE
build-essential is without plural

### DIFF
--- a/src/linux.md
+++ b/src/linux.md
@@ -22,5 +22,5 @@ TODO: https://github.com/intermezzOS/book/issues/26
 To install the other tools, on Debian:
 
 ```bash
-$ sudo apt-get install nasm xorriso qemu build-essentials
+$ sudo apt-get install nasm xorriso qemu build-essential
 ```


### PR DESCRIPTION
make install code copy-paste safe by fixing the name of the build-essential package
(it was correct in the commit message ;)
