### PR TITLE
first pass at update osx install chapter

### DIFF
--- a/src/osx.md
+++ b/src/osx.md
@@ -1,12 +1,17 @@
 # Mac OS X
 
-For now, the easiest way to get going is to install Linux on a virtual
-machine, and follow the [Linux instructions](./linux.html).
+The tools you need are similar to the tools listed in the [Linux instructions](./linux.html), but we will need to build a cross compiler in order to get things working. This is sort of complicated and boring, but we've done some of that boring work for you so you can get up and running quickly.
 
-Otherwise, to install the other tools on Mac OS X, make sure to have [homebrew](http://brew.sh/) installed.
+Make sure you have [homebrew](http://brew.sh/) installed because you are going to need it to install some of the tools. You are probably also going to need [Xcode](https://developer.apple.com/xcode/download/) if you don't already have it.
 
-Then you can run the following command:
+Download [this script](https://gist.githubusercontent.com/emkay/a1214c753e8c975d95b4/raw/cc73290537898799fe1168edfbc5a41351184670/build-grub-osx.sh) and *read* through it. There are a couple assumptions that it makes that you might want to change. When possible we try and use `brew` to install things. The compiled special versions of the tools are installed in `~/opt`. This is so we don't clobber any version of them that you may have already installed. The source code for these tools are downloaded in `~/src`.
 
-```
-brew install nasm xorriso qemu
-```
+Here is what the script does:
+
+1. `brew install` tools that it can like `gmp`, `mpfr`, `libmpc`, `autoconf`, and `automake`
+2. Download and compile tools in order to make a cross compiler: `binutils`, `gcc`, `objconv`
+3. Download and compile `grub` using the cross compiler
+
+This might take some time to run.
+
+After it is done you should have all the tools you need located in `~/opt`. The tools _should_ be named the same as the tools used in other chapters, but they might be prefixed with a `x86_64-pc-elf-`. The exception to this is `grub`.

--- a/src/osx.md
+++ b/src/osx.md
@@ -2,9 +2,9 @@
 
 The tools you need are similar to the tools listed in the [Linux instructions](./linux.html), but we will need to build a cross compiler in order to get things working. This is sort of complicated and boring, but we've done some of that boring work for you so you can get up and running quickly.
 
-Make sure you have [homebrew](http://brew.sh/) installed because you are going to need it to install some of the tools. You are probably also going to need [Xcode](https://developer.apple.com/xcode/download/) if you don't already have it.
+Make sure you have [homebrew](http://brew.sh/) installed because you are going to need it to install some of the tools. You are probably also going to need [Xcode](https://developer.apple.com/xcode/download/) if you don't already have it. You _may_ have to agree to the Xcode license before you use it. You can do this by either opening Xcode and accepting the license agreement, or by running `sudo xcodebuild -license` in the terminal, scrolling down to the bottom of the license, and agreeing to it.
 
-Download [this script](https://gist.githubusercontent.com/emkay/a1214c753e8c975d95b4/raw/cc73290537898799fe1168edfbc5a41351184670/build-grub-osx.sh) and *read* through it. There are a couple assumptions that it makes that you might want to change. When possible we try and use `brew` to install things. The compiled special versions of the tools are installed in `~/opt`. This is so we don't clobber any version of them that you may have already installed. The source code for these tools are downloaded in `~/src`.
+Download [this script](https://gist.githubusercontent.com/emkay/a1214c753e8c975d95b4/raw/cc73290537898799fe1168edfbc5a41351184670/build-grub-osx.sh) and *read* through it. There are a couple assumptions that it makes about the paths where the source is downloaded to and where the binaries are installed. You might want to change where those locations are. When possible we try and use `brew` to install things, but there are some programs we need to compile. The compiled special versions of the tools are installed in `~/opt`. This is so we don't clobber any version of them that you may have already installed. The source code for these tools are downloaded in `~/src`.
 
 Here is what the script does:
 


### PR DESCRIPTION
@steveklabnik @ashleygwilliams 

I've updated the OS X chapter and pointed folks to use the script that I made. This might be a good starting point, but I have some ideas for some other stuff and would love your feedback.

A couple of things:
1. It would be nice to have some of this integrated in the `Makefile` so that it checks for Linux/Darwin and runs the right stuff. I'm not exactly sure what the answer to this is. Maybe we could add a bit int he `Makefile` chapter that explains some of the OS X specific stuff and how to use the toolchain that we made from the script. It might be confusing if it isn't explained at that point.
2. We might want to put the actual script somewhere. Maybe in the kernel repo?
3. I'm not sure if we actually need `xorriso` or not, maybe someone can confirm. It is not installed by the script right now, but can easily be added since it is just adding a package to the `brew install`.

:sparkling_heart: :tada: :gem: :goat: 
