### PR TITLE
more detail to troubleshoot 'Could not read from CDROM'

### DIFF
--- a/src/appendix/troubleshooting.md
+++ b/src/appendix/troubleshooting.md
@@ -36,6 +36,14 @@ The solution may be to install the `grub-pc-bin` package:
 $ sudo apt-get install grub-pc-bin
 ```
 
+After the install is complete, you will need to recreate the ISO file
+before trying QEMU again:
+
+```bash
+$ grub-mkrescue -o os.iso isofiles
+$ qemu-system-x86_64 -cdrom os.iso
+```
+
 ### xorriso : FAILURE : Cannot find path ‘/efi.img’ in loaded ISO image
 
 When building the ISO, you may see a message like this:


### PR DESCRIPTION
explicitly state that the ISO file needs to be recreated after installing `grub-pc-bin`

especially as it seems to be common for everyone running Ubuntu
