### PR TITLE
Fix typo

### DIFF
--- a/src/tools.md
+++ b/src/tools.md
@@ -65,7 +65,7 @@ devices like CD drives or display screens.
 In assembly we can only do very simple things: move data between registers or
 to/from RAM; perform simple arithmetic like addition, subtraction, multiplication
 and division; compare values in different registers, and based on these comparisons
-jump to different points in our code (á la GOTO). Fancy high level concepts
+jump to different points in our code (à la GOTO). Fancy high level concepts
 like while loops and if statements, let alone garbage collection are nowhere to be
 found. Even functions as you know them aren't really supported in assembly.
 Each assembly program is just a bunch of data in registers or in memory and a


### PR DESCRIPTION
Assuming "à la" comes from French, in which case it's spelt with an "accent grave", not an "accent aigu".
