### PR TITLE
Add git clone step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 This project is built using [Rust], so you'll need to
-install Rust in order to build the book. 
+install Rust in order to build the book.
 
 [`multi-rust`] is the recommended way to install Rust.
 
@@ -12,9 +12,11 @@ You also can download Rust [here][1].
 ## Up and Running
 
 ```
+$ git clone git@github.com:intermezzOS/book.git intermezzOS/book
+$ cd intermezzOS/book
 $ cargo install mdbook
 $ mdbook build
-``` 
+```
 
 The [`mdbook`] crate builds from `markdown` files in `/src`,
 creating `html` files in a `/book` directory.


### PR DESCRIPTION
Make it crystal clear how to build the book by specifying the prerequisite `git clone` and `cd book` steps.

`book` is a very generic directory name, so perhaps it makes sense to suggest a `mkdir intermezzOS` first?
