### PR TITLE
Fix typo in multiboot headers chapter

### DIFF
--- a/src/multiboot-headers.md
+++ b/src/multiboot-headers.md
@@ -337,7 +337,7 @@ header_start:
     ; required end tag
     dw 0    ; type
     dw 0    ; flags
-    dd 8    ; size
+    dw 8    ; size
 header_end:
 ```
 
@@ -367,7 +367,7 @@ header_start:
     ; required end tag
     dw 0    ; type
     dw 0    ; flags
-    dd 8    ; size
+    dw 8    ; size
 header_end:
 ```
 


### PR DESCRIPTION
The chapter about multiboot headers instructs readers to use `dd` for the `size` component of the multiboot header end tag. However, the kernel repo seems to indicate that it should be `dw`, not `dd`. So I think it was a typo.
