### PR TITLE
Update paging.md

### DIFF
--- a/src/paging.md
+++ b/src/paging.md
@@ -353,7 +353,7 @@ another bit. This extra `1` is a ‘huge page’ bit, meaning that the pages are
 
 Just like before, we are now writing the value in `eax` to a location. But
 instead of it being just `p2_table + 0`, we’re adding `ecx * 8` Remember, `ecx`
-is our loop counter. Each entry is eight bytes in size: `0b10000011`. So we need
+is our loop counter. Each entry is eight bits in size: `0b10000011`. So we need
 to multiply the counter by eight, and then add it to `p2_table`. Let’s take a
 closer look: let’s assume `p2_table` is zero, to make the math easier:
 


### PR DESCRIPTION
If I understand this correctly, bits and bytes are mixed up in this one. After the table showing how mapping the level 1 pages actually work it says one page table needs eight bits, but above it says there are eight bytes. The former seems more logical to me, especially since you showed it with `0b10000011`.

Not a big deal, but may help to avoid confusion
