### PR TITLE
Add a reminder for Mac users to use the tools installed earlier in the book

### DIFF
--- a/src/hello-world.md
+++ b/src/hello-world.md
@@ -361,6 +361,11 @@ together:
 $ ld --nmagic --output=kernel.bin --script=linker.ld multiboot_header.o boot.o
 ```
 
+Recall that on Mac OS X you will want to use the linker we installed to
+`~/opt` and not your system linker. For example, if you did not change any of
+the defaults in the installation script, this linker will be located at
+`$HOME/opt/binx86_64-pc-elf-ld`.
+
 By running this command, we do a few things:
 
 ```text

--- a/src/hello-world.md
+++ b/src/hello-world.md
@@ -364,7 +364,7 @@ $ ld --nmagic --output=kernel.bin --script=linker.ld multiboot_header.o boot.o
 Recall that on Mac OS X you will want to use the linker we installed to
 `~/opt` and not your system linker. For example, if you did not change any of
 the defaults in the installation script, this linker will be located at
-`$HOME/opt/binx86_64-pc-elf-ld`.
+`$HOME/opt/bin/x86_64-pc-elf-ld`.
 
 By running this command, we do a few things:
 


### PR DESCRIPTION
I added a reminder for Mac users to use the linker that we install in section 2.3 and not the system linker. I'm not sure if this would be beneficial for others but I know I sped through that section because I was so excited to jump in, and I forgot that I should be using the tools we installed in that section and not the tools, such as the linker, already present on my system. This is a follow up to #143.
