### PR TITLE
Use brew prefix instead of hardcoded paths

### DIFF
--- a/src/appendix/osx-install.md
+++ b/src/appendix/osx-install.md
@@ -65,7 +65,7 @@ if [ ! -d "gcc-5.3.0" ]; then
   rm gcc-5.3.0.tar.bz2
   mkdir -p build-gcc
   cd build-gcc
-  ../gcc-5.3.0/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers --with-gmp=/usr/local/Cellar/gmp/6.1.0 --with-mpfr=/usr/local/Cellar/mpfr/3.1.3 --with-mpc=/usr/local/Cellar/libmpc/1.0.3
+  ../gcc-5.3.0/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers --with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr) --with-mpc=$(brew --prefix libmpc)
   make all-gcc
   make all-target-libgcc
   make install-gcc


### PR DESCRIPTION
The OSX install script didn't work for me because homebrew installed a newer version of one of the dependencies. Rather than using a hardcoded path, we can use `brew --prefix <lib>` to get the path to where homebrew installed the lib.
