### PR TITLE
Don't use "append" for adding things at the beginning

### DIFF
--- a/src/automation-with-make.md
+++ b/src/automation-with-make.md
@@ -330,7 +330,7 @@ build/kernel.bin: build/multiboot_header.o build/boot.o linker.ld
         ld -n -o build/kernel.bin -T linker.ld build/multiboot_header.o build/boot.o
 ```
 
-We append `build` in no fewer than _six_ places. Whew! At least it’s
+We add `build` in no fewer than _six_ places. Whew! At least it’s
 straightforward.
 
 ```makefile


### PR DESCRIPTION
"Append" generally means "add at the end", but we're adding the directory name at the beginning, so it's not the right word here.
