### PR TITLE
Add mtools installation for Arch Linux

### DIFF
--- a/src/linux.md
+++ b/src/linux.md
@@ -18,7 +18,7 @@ $ sudo apt-get install nasm xorriso qemu build-essential
 On Arch Linux you can install them with
 
 ```bash
-$ sudo pacman -S --needed binutils grub libisoburn nasm qemu
+$ sudo pacman -S --needed binutils grub mtools libisoburn nasm qemu
 ```
 
 And on Fedora with


### PR DESCRIPTION
You can have the following error running your own OS (based on intermezzOS) on a Arch system: `grub-mkrescue: error: 'mformat' invocation failed`.  
The solution is to install `mtools` via `pacman`.