### PR TITLE
Fixed a typo in xargo build commands

### DIFF
--- a/src/creating-our-first-crate.md
+++ b/src/creating-our-first-crate.md
@@ -111,7 +111,7 @@ now, while we're doing all this other setup.
 
 [hosts and targets]: setup.html#Hosts%20&%20Targets
 
-Create a file named `x86_64-unknown-intermezzos-gnu.json` inside the `target/release` directory, and put this in it:
+Create a file named `x86_64-unknown-intermezzos-gnu.json`, and put this in it:
 
 ```json
 {

--- a/src/creating-our-first-crate.md
+++ b/src/creating-our-first-crate.md
@@ -111,7 +111,7 @@ now, while we're doing all this other setup.
 
 [hosts and targets]: setup.html#Hosts%20&%20Targets
 
-Create a file named `x86_64-unknown-intermezzos-gnu.json`, and put this in it:
+Create a file named `x86_64-unknown-intermezzos-gnu.json` inside the `target/release` directory, and put this in it:
 
 ```json
 {

--- a/src/creating-our-first-crate.md
+++ b/src/creating-our-first-crate.md
@@ -207,7 +207,7 @@ $ rustup component add rust-src
 And now let's build:
 
 ```bash
-$ xargo build --release --target x86_64-unknown-intermezzos-gnu
+$ xargo build --release --target=x86_64-unknown-intermezzos-gnu
    Compiling sysroot for x86_64-unknown-intermezzos-gnu
    Compiling core v0.0.0 (file:///home/steve/.xargo/src/libcore)
    Compiling alloc v0.0.0 (file:///home/steve/.xargo/src/liballoc)

--- a/src/creating-our-first-crate.md
+++ b/src/creating-our-first-crate.md
@@ -276,7 +276,7 @@ should never return, so we put in an inifinite `loop`.
 Let's try compiling again:
 
 ```bash
-$ xargo build --release --target x86_64-unknown-intermezzos-gnu
+$ xargo build --release --target=x86_64-unknown-intermezzos-gnu
    Compiling intermezzos v0.1.0 (file:///path/to/your/kernel)
 $
 ```


### PR DESCRIPTION
EDIT: I just realized that the target specification file _should_ be in the main folder, my bad.

These changes fix the omission of equals signs in the "xargo build" command snippets.

Mine would not run without them.