### PR TITLE
Clarify make's dependency semantics

### DIFF
--- a/src/creating-our-first-crate.md
+++ b/src/creating-our-first-crate.md
@@ -359,7 +359,7 @@ default: build
         
 build: target/kernel.bin
 
-.PHONY: clean
+.PHONY: default build run clean
 
 target/multiboot_header.o: src/asm/multiboot_header.asm
         mkdir -p target
@@ -394,7 +394,7 @@ default: build
         
 build: target/kernel.bin
 
-.PHONY: clean
+.PHONY: default build run clean
 
 target/multiboot_header.o: src/asm/multiboot_header.asm
         mkdir -p target


### PR DESCRIPTION
I wonder if perhaps it is unnecessarily confusing to introduce `.PHONY` at this stage. Maybe all references to `.PHONY` should be removed? If not, then it doesn't make sense to apply it to `clean` but not the other phony targets.