### PR TITLE
update bootimage build command

### DIFF
--- a/second-edition/src/hello-world/setting-up-a-project.md
+++ b/second-edition/src/hello-world/setting-up-a-project.md
@@ -225,7 +225,7 @@ To build the project, we use the *bootimage* tool we installed earlier. Run
 this:
 
 ```bash
-$ bootimage --target=intermezzos
+$ bootimage build --target=intermezzos.json
 ```
 
 The target flag must have the same name as the `.json` file you've made, so


### PR DESCRIPTION
Hi! I walked through chapter 2 of the 2nd edition last night, and this it looks like the syntax for the `bootimage build` command has changed slightly. That said, the error messages that `bootimage` gave were very easy to follow, so I don't think you will lose too many people even if you don't update the book.

Also, thanks for writing this! I went from not knowing anything about how OSes worked to being able to explain something in general terms to my partner who doesn't code. :)