### PR TITLE
Update cargo to make a library, not binary

### DIFF
--- a/first-edition/src/creating-our-first-crate.md
+++ b/first-edition/src/creating-our-first-crate.md
@@ -5,7 +5,7 @@ also installed Cargo for us, Rust's build tool and package manager. Generate
 a new Cargo package like this:
 
 ```bash
-$ cargo init --name intermezzos
+$ cargo init --name intermezzos --lib
 ```
 
 This will create a new package called '`intermezzos`' in the current directory.


### PR DESCRIPTION
cargo, by default (in 2018) if you do not specify if it's --lib, it generates a binary package while the book assumes a library package.