### PR TITLE
Fix objconv.zip curl request in OSX install script

### DIFF
--- a/first-edition/src/appendix/osx-install.md
+++ b/first-edition/src/appendix/osx-install.md
@@ -80,7 +80,7 @@ if [ ! -d "objconv" ]; then
   echo ""
   echo "Installing \`objconv\`"
   echo ""
-  curl http://www.agner.org/optimize/objconv.zip > objconv.zip
+  curl -L https://www.agner.org/optimize/objconv.zip > objconv.zip
   mkdir -p build-objconv
   unzip objconv.zip -d build-objconv
   cd build-objconv


### PR DESCRIPTION
URL has moved to https. http URL gives 301 redirect which breaks script (downloads html page instead of zip). See issue https://github.com/intermezzOS/book/issues/198