### PR TITLE
Update osx-install.md

### DIFF
--- a/first-edition/src/appendix/osx-install.md
+++ b/first-edition/src/appendix/osx-install.md
@@ -99,6 +99,7 @@ if [ ! -d "grub" ]; then
   echo ""
   git clone --depth 1 git://git.savannah.gnu.org/grub.git
   cd grub
+  ./bootstrap
   sh autogen.sh
   mkdir -p build-grub
   cd build-grub

--- a/first-edition/src/appendix/osx-install.md
+++ b/first-edition/src/appendix/osx-install.md
@@ -33,7 +33,7 @@ mkdir -p "$HOME/src"
 mkdir -p "$PREFIX"
 
 # gmp mpfr libmpc
-brew install gmp mpfr libmpc autoconf automake nasm xorriso qemu
+brew install gmp mpfr libmpc autoconf automake nasm xorriso qemu pkg-config
 
 # binutils
 


### PR DESCRIPTION
When I get to `sh autogen.sh` in the `grub` section, I get an error and the script stops: `Gnulib not yet bootstrapped; run ./bootstrap instead.` I manually ran it and ended up getting an error in this SO post, ran `brew install pkg-config` and re-ran and all went well.
https://stackoverflow.com/questions/8811381/possibly-undefined-macro-ac-msg-error