### PR TITLE
Update osx-install.md - x86_64-pc-elf-gcc: command not found

### DIFF
--- a/first-edition/src/appendix/osx-install.md
+++ b/first-edition/src/appendix/osx-install.md
@@ -102,6 +102,7 @@ if [ ! -d "grub" ]; then
   sh autogen.sh
   mkdir -p build-grub
   cd build-grub
+  export PATH=$PATH:~/opt/bin
   ../configure --disable-werror TARGET_CC=$TARGET-gcc TARGET_OBJCOPY=$TARGET-objcopy \
     TARGET_STRIP=$TARGET-strip TARGET_NM=$TARGET-nm TARGET_RANLIB=$TARGET-ranlib --target=$TARGET --prefix="$PREFIX"
   make


### PR DESCRIPTION
The error below occurs when running `../configure --disable-werror ...`, I assume, because all the `x86_64-pc-elf-` files aren't on the path. Adding `export PATH=$PATH:~/opt/bin` seems to fix it, but maybe theres a better way?

```
...
checking whether wcwidth works reasonably in UTF-8 locales... no
checking for stdint.h... (cached) yes
checking which extra warnings work...  -Wextra -Wattributes -Wendif-labels -Winit-self -Wint-to-pointer-cast -Winvalid-pch -Wmissing-field-initializers -Wnonnull -Woverflow -Wvla -Wpointer-to-int-cast -Wstrict-aliasing -Wvariadic-macros -Wvolatile-register-var -Wpointer-sign -Wmissing-include-dirs -Wmissing-prototypes -Wmissing-declarations -Wformat=2
checking for x86_64-pc-elf-gcc... x86_64-pc-elf-gcc
checking for x86_64-pc-elf-objcopy... x86_64-pc-elf-objcopy
checking for x86_64-pc-elf-strip... x86_64-pc-elf-strip
checking for x86_64-pc-elf-nm... x86_64-pc-elf-nm
checking for x86_64-pc-elf-ranlib... x86_64-pc-elf-ranlib
../configure: line 30782: x86_64-pc-elf-gcc: command not found
checking which extra warnings work... 
checking if compiling with clang... yes
checking for options to compile assembly... configure: error: could not compile assembly
```